### PR TITLE
Hair icon UOL handling, faces with IDs above 50000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,5 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+*.csproj
+WzVisualizer/WzVisualizer.csproj

--- a/.gitignore
+++ b/.gitignore
@@ -259,5 +259,3 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
-*.csproj
-WzVisualizer/WzVisualizer.csproj

--- a/WzVisualizer/GUI/Form1.cs
+++ b/WzVisualizer/GUI/Form1.cs
@@ -88,7 +88,16 @@ namespace WzVisualizer {
         private void AddHairRow(WzImage image) {
             string imgName = Path.GetFileNameWithoutExtension(image.Name);
             int id = int.Parse(imgName);
-            WzCanvasProperty icon = (WzCanvasProperty)image.GetFromPath("default/hairOverHead");
+            WzCanvasProperty icon = null;
+            WzImageProperty hairOverHeadProperty = image.GetFromPath("default/hairOverHead");
+            if (hairOverHeadProperty is WzCanvasProperty wcp)
+            {
+                icon = wcp;
+            }
+            else if (hairOverHeadProperty is WzUOLProperty wup)
+            {
+                icon = (WzCanvasProperty)wup.LinkValue;
+            }
             if (icon == null) {
                 icon = (WzCanvasProperty)image.GetFromPath("default/hair");
             }
@@ -216,7 +225,7 @@ namespace WzVisualizer {
                             switch (bodyPart) {
                                 default:
                                     if (selectedTab == 2 && bodyPart >= 130 && bodyPart <= 170) AddGridRow(EquipWeaponsView.GridView, image);
-                                    else if (selectedTab == 1 && bodyPart == 2) AddFaceRow(image);
+                                    else if (selectedTab == 1 && (bodyPart == 2 || bodyPart == 5)) AddFaceRow(image);
                                     else if (selectedTab == 0 && (bodyPart == 3 || bodyPart == 4)) AddHairRow(image);
                                     break;
                                 case 100: // Caps

--- a/WzVisualizer/GUI/Form1.cs
+++ b/WzVisualizer/GUI/Form1.cs
@@ -88,16 +88,7 @@ namespace WzVisualizer {
         private void AddHairRow(WzImage image) {
             string imgName = Path.GetFileNameWithoutExtension(image.Name);
             int id = int.Parse(imgName);
-            WzCanvasProperty icon = null;
-            WzImageProperty hairOverHeadProperty = image.GetFromPath("default/hairOverHead");
-            if (hairOverHeadProperty is WzCanvasProperty wcp)
-            {
-                icon = wcp;
-            }
-            else if (hairOverHeadProperty is WzUOLProperty wup)
-            {
-                icon = (WzCanvasProperty)wup.LinkValue;
-            }
+            WzCanvasProperty icon = (WzCanvasProperty)image.GetFromPath("default/hairOverHead");
             if (icon == null) {
                 icon = (WzCanvasProperty)image.GetFromPath("default/hair");
             }
@@ -225,7 +216,7 @@ namespace WzVisualizer {
                             switch (bodyPart) {
                                 default:
                                     if (selectedTab == 2 && bodyPart >= 130 && bodyPart <= 170) AddGridRow(EquipWeaponsView.GridView, image);
-                                    else if (selectedTab == 1 && (bodyPart == 2 || bodyPart == 5)) AddFaceRow(image);
+                                    else if (selectedTab == 1 && bodyPart == 2) AddFaceRow(image);
                                     else if (selectedTab == 0 && (bodyPart == 3 || bodyPart == 4)) AddHairRow(image);
                                     break;
                                 case 100: // Caps

--- a/WzVisualizer/WzStringUtility.cs
+++ b/WzVisualizer/WzStringUtility.cs
@@ -47,8 +47,8 @@ namespace WzVisualizer {
         private static string GetEqpCategory(int ID) {
             switch (ID / 10000) {
                 default: return null;
-                case 2: case 5: return "Face";
-                case 3: case 4: return "Hair";
+                case 2: return "Face";
+                case 3: return "Hair";
                 case 100: return "Cap";
                 case 101:
                 case 102:

--- a/WzVisualizer/WzStringUtility.cs
+++ b/WzVisualizer/WzStringUtility.cs
@@ -47,8 +47,8 @@ namespace WzVisualizer {
         private static string GetEqpCategory(int ID) {
             switch (ID / 10000) {
                 default: return null;
-                case 2: return "Face";
-                case 3: return "Hair";
+                case 2: case 5: return "Face";
+                case 3: case 4: return "Hair";
                 case 100: return "Cap";
                 case 101:
                 case 102:


### PR DESCRIPTION
Some newer hairs cause [unhandled InvalidCastExceptions](https://github.com/izarooni/WzVisualizer/blob/0f6a7648b41d61480daa65a86e95e105aa76cf95/WzVisualizer/GUI/Form1.cs#L91) due to their hairOverHead node using a UOL.

Some newer faces use IDs 50000-59999 (KMS I think) which some users may have imported to other versions.